### PR TITLE
Fix BMS loading

### DIFF
--- a/General.targets
+++ b/General.targets
@@ -27,6 +27,11 @@
             <Private>false</Private>
             <SpecificVersion>false</SpecificVersion>
         </Reference>
+		<Reference Include="Il2CppSystem.Core">
+			<HintPath>$(RefPath)\Il2CppSystem.Core.dll</HintPath>
+			<Private>false</Private>
+            <SpecificVersion>false</SpecificVersion>
+		</Reference>
         <Reference Include="NAudio">
             <HintPath>$(RefPath)NAudio.dll</HintPath>
             <Private>false</Private>

--- a/src/Album.cs
+++ b/src/Album.cs
@@ -29,10 +29,10 @@ namespace CustomAlbums
         private static readonly Logger Log = new Logger("Album");
         public static readonly ManagedGeneric.Dictionary<string, AudioFormat> AudioFormatMapping = new ManagedGeneric.Dictionary<string, AudioFormat>()
             {
-                {".aiff", AudioFormat.aiff},
-                {".mp3", AudioFormat.mp3},
+                //{".aiff", AudioFormat.aiff},
+                //{".mp3", AudioFormat.mp3},
                 {".ogg", AudioFormat.ogg},
-                {".wav", AudioFormat.wav},
+                //{".wav", AudioFormat.wav},
             };
 
         public AlbumInfo Info { get; private set; }
@@ -166,15 +166,15 @@ namespace CustomAlbums
                 switch (format)
                 {
                     case AudioFormat.aiff:
-                        waveStream = new AiffFileReader(stream);
+                        //waveStream = new AiffFileReader(stream);
                         break;
                     case AudioFormat.mp3:
-                        Log.Debug("MP3 Decode start");
-                        var a = new MP3Stream(buffer.ToStream());
-                        Log.Debug($"MP3 Decode {a.Length}");
+                        //Log.Debug("MP3 Decode start");
+                        //var a = new MP3Stream(buffer.ToStream());
+                        //Log.Debug($"MP3 Decode {a.Length}");
                         break;
                     case AudioFormat.wav:
-                        waveStream = new WaveFileReader(stream);
+                        //waveStream = new WaveFileReader(stream);
                         break;
                     case AudioFormat.ogg:
                         waveStream = new VorbisWaveReader(stream);
@@ -219,35 +219,40 @@ namespace CustomAlbums
                      * 3.´´½¨StageInfo
                      * */
 
-                    //var bms = BMSCLoader.Load(stream, $"map_{index}");
-                    var bms = Singleton<iBMSCManager>.instance.Load("test");
+                    var pkgName = $"{(IsPackaged ? "pkg" : "fs")}_{Info.name}";
+                    var mapName = $"{pkgName}_map{index}";
+
+                    var bms = BMSCLoader.Load(stream, mapName);
                     if (bms == null)
                     {
                         return null;
                     }
 
-                    MusicConfigReader reader = GameLogic.MusicConfigReader.Instance;
+                    MusicConfigReader reader = MusicConfigReader.Instance;
                     reader.ClearData();
                     reader.bms = bms;
-                    reader.Init("");
+                    reader.Init(mapName);
 
-
-                    //var info = LinqUtils.Cast<MusicData>(reader.GetData());
-                    var musicDatas = reader.GetData().Cast<Il2CppGeneric.IEnumerable<MusicData>>();
+                    var musicDatas = reader.GetData();
+                    var il2cppDatas = new Il2CppGeneric.List<MusicData>();
+                    foreach(var data in musicDatas) {
+                        il2cppDatas.Add(data.Cast<MusicData>());
+                    }
 
                     StageInfo stageInfo = new StageInfo
                     {
-                        musicDatas = new Il2CppGeneric.List<MusicData>(musicDatas),
+                        musicDatas = il2cppDatas,
                         delay = reader.delay,
-                        mapName = (string)reader.bms.info["TITLE"],
-                        //music = ((string)reader.bms.info["WAV10"]).BeginBefore('.'),
+                        mapName = mapName,
+                        music = $"{pkgName}_music",
                         scene = (string)reader.bms.info["GENRE"],
                         difficulty = index,
                         bpm = reader.bms.GetBpm(),
                         md5 = reader.bms.md5,
-                        sceneEvents = reader.sceneEvents
+                        sceneEvents = reader.sceneEvents,
+                        name = Info.name
                     };
-                    Log.Debug($"Delay: {reader.delay}");
+                    Log.Debug($"Delay: {reader.delay.ToString()}");
                     return stageInfo;
                 }
             }

--- a/src/BMSCLoader.cs
+++ b/src/BMSCLoader.cs
@@ -1,16 +1,10 @@
-using Assets.Scripts.GameCore.Managers;
-using Assets.Scripts.PeroTools.Commons;
-using Newtonsoft.Json.Linq;
+using Il2CppNewtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Security.Cryptography;
-using System.Text;
 using UnityEngine;
-using Sirenix.Utilities;
 using static Assets.Scripts.GameCore.Managers.iBMSCManager;
 using System.Text.RegularExpressions;
-using System.Linq;
 
 namespace CustomAlbums
 {
@@ -25,192 +19,174 @@ namespace CustomAlbums
 		/// <param name="stream"></param>
 		/// <param name="bmsName"></param>
 		/// <returns></returns>
-		//public static BMS Load(Stream stream, string bmsName)
-		//{
-		//	JObject header = new JObject();
-		//	Dictionary<string, float> BPMExt = new Dictionary<string, float>();
-		//	List<JObject> BPMList = new List<JObject>();
-		//	List<JObject> notes = new List<JObject>();
-		//	List<JObject> notesPercent = new List<JObject>();
+		public static BMS Load(Stream stream, string bmsName) {
+			JObject header = new JObject();
+			Dictionary<string, float> BPMExt = new Dictionary<string, float>();
+			List<JObject> BPMList = new List<JObject>();
+			JArray notes = new JArray();
+			JArray notesPercent = new JArray();
 
-		//	// Calculate MD5 of bms bytes
-		//	string md5 = stream.ToArray().GetMD5().ToString("x2");
-		//	stream.Position = 0; // reset position
+			// Calculate MD5 of bms bytes
+			string md5 = stream.ToArray().GetMD5().ToString("x2");
+			stream.Position = 0; // reset position
 
-		//	StreamReader streamReader = new StreamReader(stream);
-		//	string line;
-		//	// Parse bms file
-		//	while ((line = streamReader.ReadLine()) != null)
-		//	{
-		//		line = line.Trim();
-  //              if (!line.StartsWith("#"))
-		//			continue;
+			StreamReader streamReader = new StreamReader(stream);
+			string line;
+			// Parse bms file
+			while((line = streamReader.ReadLine()) != null) {
+				line = line.Trim();
+				if(!line.StartsWith("#"))
+					continue;
 
-		//		line = line.Substring(1); // Remove start '#'
+				line = line.Substring(1); // Remove start '#'
 
-		//		// Parse header field
-		//		if (line.Contains(" "))
-		//		{
-		//			var fileds = line.Split(new char[] { ' ' }, 2);
-		//			string key = fileds[0];
-		//			string value = fileds[1];
+				// Parse header field
+				if(line.Contains(" ")) {
+					var fileds = line.Split(new char[] { ' ' }, 2);
+					string key = fileds[0];
+					string value = fileds[1];
 
-		//			header[key] = value;
+					header[key] = value;
 
-		//			if (key == "BPM")
-		//			{
-		//				// Set default bpm
-		//				float freq = 60f / float.Parse(value) * 4f;
-		//				JObject jObject = new JObject();
-		//				jObject["tick"] = 0f;
-		//				jObject["freq"] = freq;
-		//				BPMList.Add(jObject);
-		//			}
-		//			else if (key.Contains("BPM"))
-		//			{
-		//				// Extended BPM
-		//				BPMExt.Add(key.RemoveFromStart("BPM"), float.Parse(value));
-		//			}
-		//			continue;
-		//		}
+					if(key == "BPM") {
+						// Set default bpm
+						float freq = 60f / float.Parse(value) * 4f;
+						JObject jObject = new JObject();
+						jObject["tick"] = 0f;
+						jObject["freq"] = freq;
+						BPMList.Add(jObject);
+					} else if(key.Contains("BPM")) {
+						// Extended BPM
+						BPMExt.Add(key.RemoveFromStart("BPM"), float.Parse(value));
+					}
+					continue;
+				}
 
-		//		// Parse main data field
-		//		var match = MainDataRegex.Match(line);
-		//		if (!match.Success)
-		//			continue;
+				// Parse main data field
+				var match = MainDataRegex.Match(line);
+				if(!match.Success)
+					continue;
 
-		//		var measure = int.Parse(match.Groups[1].Value);
-		//		var channel = match.Groups[2].Value;
-		//		var rawData = match.Groups[3].Value;
+				var measure = int.Parse(match.Groups[1].Value);
+				var channel = match.Groups[2].Value;
+				var rawData = match.Groups[3].Value;
 
-		//		int dataLength = rawData.Length / 2;
-		//		for (int i = 0; i < dataLength; i++)
-		//		{
-		//			string data = rawData.Substring(i * 2, 2);
-		//			if ("00" == data)
-		//				continue; // Skip
+				int dataLength = rawData.Length / 2;
+				for(int i = 0; i < dataLength; i++) {
+					string data = rawData.Substring(i * 2, 2);
+					if("00" == data)
+						continue; // Skip
 
-		//			float currentTick = (float)i / (float)dataLength + (float)measure;
+					float currentTick = (float)i / (float)dataLength + (float)measure;
 
-		//			if ("02" == channel)
-		//			{
-		//				// 小节的缩短
-		//				JObject jObject = new JObject();
-		//				jObject["beat"] = channel;
-		//				jObject["percent"] = float.Parse(rawData);
-		//				notesPercent.Add(jObject);
-		//				break; // 跳过剩余数据
-		//			}
-		//			else if("03" == channel || "08" == channel)
-		//			{
-		//				// 变速
-		//				float bpm = 0f;
-		//				if ("08" == channel && BPMExt.ContainsKey(data))
-		//					bpm = BPMExt[data];// 扩展变速
-		//				else
-		//					bpm = Convert.ToInt32(data, 16);
-		//				JObject jObject = new JObject();
-		//				jObject["tick"] = currentTick;
-		//				jObject["freq"] = 60f / bpm * 4f;
-		//				BPMList.Add(jObject);
-		//				// 按照Tick从高到低排序
-		//				BPMList.Sort((x,y)=>
-		//				{
-		//					if ((float)x["tick"] > (float)y["tick"])
-		//					{
-		//						return -1;
-		//					}
-		//					return 1;
-		//				});
-		//			}
-  //                  else
-  //                  {
-		//				// note
-		//				float num3 = 0f;
-		//				float totalTick = 0f;
-		//				var BPMListBeforeTick = BPMList.FindAll((o) => (float)o["tick"] < currentTick);
-		//				for (int k = BPMListBeforeTick.Count - 1; k >= 0; k--)
-		//				{
-		//					var BPM = BPMListBeforeTick[k];
-		//					var freq = (float)BPM["freq"];
-		//					float keepTick = 0f;
-		//					if (k - 1 >= 0)
-		//					{
-		//						// 下一个速度与上一个速度相差的tick
-		//						var nextBPM = BPMListBeforeTick[k - 1];
-		//						keepTick = (float)nextBPM["tick"] - (float)BPM["tick"];
-		//					}
-		//					if (k == 0)
-		//					{
-		//						// 最后一个
-		//						keepTick = currentTick - (float)BPM["tick"];
-		//					}
+					if("02" == channel) {
+						// 小节的缩短
+						JObject jObject = new JObject();
+						jObject["beat"] = channel;
+						jObject["percent"] = float.Parse(rawData);
+						notesPercent.Add(jObject);
+						break; // 跳过剩余数据
+					} else if("03" == channel || "08" == channel) {
+						// 变速
+						float bpm = 0f;
+						if("08" == channel && BPMExt.ContainsKey(data))
+							bpm = BPMExt[data];// 扩展变速
+						else
+							bpm = Convert.ToInt32(data, 16);
+						JObject jObject = new JObject();
+						jObject["tick"] = currentTick;
+						jObject["freq"] = 60f / bpm * 4f;
+						BPMList.Add(jObject);
+						// 按照Tick从高到低排序
+						BPMList.Sort((x, y) => {
+							if((float)x["tick"] > (float)y["tick"]) {
+								return -1;
+							}
+							return 1;
+						});
+					} else {
+						// note
+						float num3 = 0f;
+						float totalTick = 0f;
+						var BPMListBeforeTick = BPMList.FindAll((o) => (float)o["tick"] < currentTick);
+						for(int k = BPMListBeforeTick.Count - 1; k >= 0; k--) {
+							var BPM = BPMListBeforeTick[k];
+							var freq = (float)BPM["freq"];
+							float keepTick = 0f;
+							if(k - 1 >= 0) {
+								// 下一个速度与上一个速度相差的tick
+								var nextBPM = BPMListBeforeTick[k - 1];
+								keepTick = (float)nextBPM["tick"] - (float)BPM["tick"];
+							}
+							if(k == 0) {
+								// 最后一个
+								keepTick = currentTick - (float)BPM["tick"];
+							}
 
-		//					float curTick = totalTick;
-		//					totalTick += keepTick;
+							float curTick = totalTick;
+							totalTick += keepTick;
 
-		//					int _curTick = Mathf.FloorToInt(curTick); // 最小取整
-		//					int _totalTick = Mathf.CeilToInt(totalTick);	// 最大取整
-		//					for (int m = _curTick; m < _totalTick; m++)
-		//					{
-		//						int index = m;
-		//						float num10 = 1f;
-		//						if (m == _curTick)
-		//						{
-		//							num10 = (float)(m + 1) - curTick;
-		//						}
-		//						if (m == _totalTick - 1)
-		//						{
-		//							num10 = totalTick - (float)(_totalTick - 1);
-		//						}
-		//						if (_totalTick == _curTick + 1)
-		//						{
-		//							num10 = totalTick - curTick;
-		//						}
-		//						JToken jtoken = notesPercent.First((pc) => (int)pc["beat"] == index);
-		//						float num11 = (jtoken == null) ? 1f : ((float)jtoken["percent"]);
-		//						num3 += (float)Mathf.RoundToInt(num10 * num11 * freq / 1E-06f) * 1E-06f;
-		//					}
+							int _curTick = Mathf.FloorToInt(curTick); // 最小取整
+							int _totalTick = Mathf.CeilToInt(totalTick);    // 最大取整
+							for(int m = _curTick; m < _totalTick; m++) {
+								int index = m;
+								float num10 = 1f;
+								if(m == _curTick) {
+									num10 = (float)(m + 1) - curTick;
+								}
+								if(m == _totalTick - 1) {
+									num10 = totalTick - (float)(_totalTick - 1);
+								}
+								if(_totalTick == _curTick + 1) {
+									num10 = totalTick - curTick;
+								}
 
-		//				}
-		//				JObject jObject = new JObject();
-		//				jObject["time"] = 0;
-		//				jObject["value"] = data;
-		//				jObject["tone"] = 0;
-		//				notes.Add(jObject);
-		//			}
-		//		}
-		//	}
+								JToken jtoken = null;
+								for(int x = 0; x < notesPercent.Count; x++) {
+									if((int)notesPercent[x]["beat"] == index) {
+										jtoken = notesPercent[x];
+										break;
+									}
+								}
+								float num11 = (jtoken == null) ? 1f : ((float)jtoken["percent"]);
+								num3 += (float)Mathf.RoundToInt(num10 * num11 * freq / 1E-06f) * 1E-06f;
+							}
 
-		//	notes.Sort((x, y) =>
-		//	{
-		//		if ((float)x["time"] > (float)y["time"])
-		//			return 1;
-		//		if ((float)y["time"] > (float)x["time"])
-		//			return -1;
-		//		return 0;
-		//	});
+						}
+						JObject jObject = new JObject();
+						jObject["time"] = num3;
+						jObject["value"] = data;
+						jObject["tone"] = channel;
+						notes.Add(jObject);
+					}
+				}
+			}
 
-		//	BMS bms = new BMS
-		//	{
-		//		info = Il2CppJson.,
-		//		notes = notes,
-		//		notesPercent = notesPercent,
-		//		md5 = md5
-		//	};
-		//	bms.info["NAME"] = bmsName;
-		//	bms.info["NEW"] = true;
+			notes._values.Sort((Il2CppSystem.Comparison<JToken>)((x, y) => {
+				if((float)x["time"] > (float)y["time"])
+					return 1;
+				if((float)y["time"] > (float)x["time"])
+					return -1;
+				return 0;
+			}));
 
-		//	if (bms.info.Properties().ToList<JProperty>().Find((JProperty p) => p.Name == "BANNER") == null)
-		//	{
-		//		bms.info["BANNER"] = "cover/none_cover.png";
-		//	}
-		//	else
-		//	{
-		//		bms.info["BANNER"] = "cover/" + (string)bms.info["BANNER"];
-		//	}
-		//	return bms;
-		//}
+			BMS bms = new BMS {
+				info = header,
+				notes = notes,
+				notesPercent = notesPercent,
+				md5 = md5
+			};
+			bms.info["NAME"] = bmsName;
+			bms.info["NEW"] = true;
 
+			if(Il2CppSystem.Linq.Enumerable.ToList(bms.info.Properties()).Find((Il2CppSystem.Predicate<JProperty>)((JProperty p) => p.Name == "BANNER")) == null) {
+				bms.info["BANNER"] = "cover/none_cover.png";
+			} else {
+				bms.info["BANNER"] = "cover/" + (string)bms.info["BANNER"];
+			}
+
+			var str = bms.info.ToString();
+			return bms;
+		}
 	}
 }

--- a/src/Entry.cs
+++ b/src/Entry.cs
@@ -19,7 +19,7 @@ namespace CustomAlbums
             Application.runInBackground = true;
 
             AlbumManager.LoadAll();
-            harmony.PatchAll(typeof(SteamPatch));
+            //harmony.PatchAll(typeof(SteamPatch));
 
             //harmony.PatchAll(typeof(AssetPatch));
             WebApiPatch.DoPatching();

--- a/src/Patch/AssetPatch.cs
+++ b/src/Patch/AssetPatch.cs
@@ -10,6 +10,8 @@ using MelonLoader;
 using System.Reflection;
 using UnhollowerBaseLib;
 using System.Runtime.InteropServices;
+using Assets.Scripts.PeroTools.Commons;
+using Assets.Scripts.PeroTools.Managers;
 
 namespace CustomAlbums.Patch
 {
@@ -50,12 +52,18 @@ namespace CustomAlbums.Patch
         {
             var _assetName = IL2CPP.Il2CppStringToManaged(assetName);
             //Log.Debug($"assetName {_assetName}");
+            if(_assetName == null) return OriginalLoadFromName(instance, assetName, nativeMethodInfo);
 
             // Cached asset
             if (LoadedAssets.TryGetValue(_assetName, out var asset))
             {
-                Log.Debug($"Use cache: {_assetName}");
-                return asset.Pointer;
+                if(asset != null) {
+                    Log.Debug($"Use cache: {_assetName}");
+                    return asset.Pointer;
+                } else {
+                    Log.Debug("Replacing null asset");
+                    LoadedAssets.Remove(_assetName);
+                }
             }
 
             var assetPtr = OriginalLoadFromName(instance, assetName, nativeMethodInfo);
@@ -82,6 +90,7 @@ namespace CustomAlbums.Patch
                     free = true,
                 }));
                 newAsset = CreateTextAsset(_assetName, jArray.JsonSerialize());
+                if(!Singleton<ConfigManager>.instance.m_Dictionary.ContainsKey(_assetName)) Singleton<ConfigManager>.instance.Add(_assetName, ((TextAsset)newAsset).text);
             }
             else if (_assetName == AlbumManager.JsonName)
             {
@@ -123,6 +132,7 @@ namespace CustomAlbums.Patch
                     jArray.Add(jObject);
                 }
                 newAsset = CreateTextAsset(_assetName, jArray.JsonSerialize());
+                if(!Singleton<ConfigManager>.instance.m_Dictionary.ContainsKey(_assetName)) Singleton<ConfigManager>.instance.Add(_assetName, ((TextAsset)newAsset).text);
             }
             else if (_assetName == $"albums_{lang}")
             {
@@ -133,6 +143,7 @@ namespace CustomAlbums.Patch
                     title = AlbumManager.Langs[lang],
                 }));
                 newAsset = CreateTextAsset(_assetName, jArray.JsonSerialize());
+                if(!Singleton<ConfigManager>.instance.m_Dictionary.ContainsKey(_assetName)) Singleton<ConfigManager>.instance.Add(_assetName, ((TextAsset)newAsset).text);
             }
             else if (_assetName == $"{AlbumManager.JsonName}_{lang}")
             {
@@ -146,6 +157,7 @@ namespace CustomAlbums.Patch
                     }));
                 }
                 newAsset = CreateTextAsset(_assetName, jArray.JsonSerialize());
+                if(!Singleton<ConfigManager>.instance.m_Dictionary.ContainsKey(_assetName)) Singleton<ConfigManager>.instance.Add(_assetName, ((TextAsset)newAsset).text);
             }
             else if (_assetName == "defaultTag")
             {
@@ -159,6 +171,7 @@ namespace CustomAlbums.Patch
                 music_tag["music_list"] = JArray.FromObject(AlbumManager.GetAllUid());
 
                 newAsset = CreateTextAsset(_assetName, jArray.JsonSerialize());
+                if(!Singleton<ConfigManager>.instance.m_Dictionary.ContainsKey(_assetName)) Singleton<ConfigManager>.instance.Add(_assetName, ((TextAsset)newAsset).text);
             }
 
             if (assetPtr == IntPtr.Zero)
@@ -171,20 +184,23 @@ namespace CustomAlbums.Patch
                     {
                         var albumKey = _assetName.RemoveFromEnd(suffix);
                         AlbumManager.LoadedAlbums.TryGetValue(albumKey, out var album);
-                        switch (suffix)
-                        {
-                            case "_demo":
-                                newAsset = album?.GetMusic("demo");
-                                break;
-                            case "_music":
-                                newAsset = album?.GetMusic();
-                                break;
-                            case "_cover":
-                                newAsset = album?.GetCover();
-                                break;
-                            default:
-                                Log.Debug($"Unknown suffix: {suffix}");
-                                break;
+                        if(suffix.StartsWith("_map")) {
+                            newAsset = album?.GetMap(int.Parse(suffix.Substring(4)));
+                        } else {
+                            switch(suffix) {
+                                case "_demo":
+                                    newAsset = album?.GetMusic("demo");
+                                    break;
+                                case "_music":
+                                    newAsset = album?.GetMusic();
+                                    break;
+                                case "_cover":
+                                    newAsset = album?.GetCover();
+                                    break;
+                                default:
+                                    Log.Debug($"Unknown suffix: {suffix}");
+                                    break;
+                            }
                         }
                     }
                 }

--- a/src/Patch/AssetPatch.cs
+++ b/src/Patch/AssetPatch.cs
@@ -67,6 +67,7 @@ namespace CustomAlbums.Patch
             }
 
             var assetPtr = OriginalLoadFromName(instance, assetName, nativeMethodInfo);
+            var noCache = false;
 
             if (_assetName == "LocalizationSettings")
                 return assetPtr;
@@ -186,6 +187,10 @@ namespace CustomAlbums.Patch
                         AlbumManager.LoadedAlbums.TryGetValue(albumKey, out var album);
                         if(suffix.StartsWith("_map")) {
                             newAsset = album?.GetMap(int.Parse(suffix.Substring(4)));
+
+                            // Don't cache chart StageInfos
+                            // This is to ensure the full loading process occurs every time
+                            noCache = true;
                         } else {
                             switch(suffix) {
                                 case "_demo":
@@ -209,8 +214,12 @@ namespace CustomAlbums.Patch
             // Add to cache
             if (newAsset != null)
             {
-                Log.Debug($"Cached {_assetName}");
-                LoadedAssets.Add(_assetName, newAsset);
+                if(!noCache) {
+                    Log.Debug($"Cached {_assetName}");
+                    LoadedAssets.Add(_assetName, newAsset);
+                } else {
+                    Log.Debug($"Loaded {_assetName}");
+                }
                 return newAsset.Pointer;
             }
 


### PR DESCRIPTION
Adds functional loading of charts and fixes several bugs.
Both filesystem and packaged charts are fully playable, provided they contain compatible audio assets.

Note that only the .ogg format is confirmed to be working right now, so it is the only one enabled.

Performs the following fixes and changes:
- Disabled all audio formats except for .ogg
- Updated the custom BMSCLoader
- AssetPatch now loads BMS charts
- Album.GetMap() now uses the custom BMSCLoader to load BMS charts
- Fixed unloaded assets not getting reloaded
- Fixed exception from null asset name
- Fixed JSON TextAssets being missing from ConfigManager dictionary