### PR TITLE
Add new tag for customs on top row

### DIFF
--- a/src/Patch/TagPatch.cs
+++ b/src/Patch/TagPatch.cs
@@ -1,0 +1,36 @@
+﻿using HarmonyLib;
+using Newtonsoft.Json.Linq;
+using IL2CppJson = Il2CppNewtonsoft.Json.Linq;
+using Il2CppSystem.Collections.Generic;
+using Assets.Scripts.Database;
+using Assets.Scripts.Database.DataClass;
+using static Assets.Scripts.Database.DBConfigCustomTags;
+
+namespace CustomAlbums.Patch
+{
+    /// <summary>
+    /// Adds a tag for Custom Albums on the top row.
+    /// </summary>
+    [HarmonyPatch(typeof(MusicTagManager), "InitAlbumTagInfo")]
+    internal static class TagPatch
+    {
+        private static void Postfix() {
+            var info = new AlbumTagInfo {
+                name = AlbumManager.Langs["English"],
+                tagUid = "tag-custom-albums",
+                iconName = "IconCustomAlbums"
+            };
+            var customInfo = new CustomTagInfo {
+                tag_name = JObject.FromObject(AlbumManager.Langs).JsonSerialize().IL2CppJsonDeserialize<IL2CppJson.JObject>().ToObject<Dictionary<string, string>>(),
+                tag_picture = "https://mdmc.moe/cdn/melon.png",
+            };
+            customInfo.music_list = new List<string>();
+            foreach(var uid in AlbumManager.GetAllUid()) customInfo.music_list.Add(uid);
+            
+            info.InitCustomTagInfo(customInfo);
+
+            GlobalDataBase.dbMusicTag.m_AlbumTagsSort.Insert(GlobalDataBase.dbMusicTag.m_AlbumTagsSort.Count - 4, AlbumManager.Uid);
+            GlobalDataBase.dbMusicTag.AddAlbumTagData(AlbumManager.Uid, info);
+        }
+    }
+}

--- a/src/Patch/WebApiPatch.cs
+++ b/src/Patch/WebApiPatch.cs
@@ -89,25 +89,6 @@ namespace CustomAlbums.Patch
             
             switch (_url)
             {
-                // Add custom tag.
-                case "musedash/v1/music_tag":
-                    _succeedCallback = new Action<IL2CppJson.JObject>(jObject =>
-                    {
-                        Log.Debug("Injected: musedash/v1/music_tag");
-                        var JObj = jObject.IL2CppJsonSerialize().JsonDeserialize<JObject>();
-                        var jArray = JObj["music_tag_list"];
-                        var music_tag = jArray.First(o => o["sort_key"].Value<int>() == 8);
-
-                        music_tag["tag_name"] = JObject.FromObject(AlbumManager.Langs);
-                        music_tag["tag_picture"] = "https://mdmc.moe/cdn/melon.png";
-                        music_tag["icon_name"] = "";
-                        music_tag["music_list"] = JArray.FromObject(AlbumManager.GetAllUid());
-
-                        var newJObject = JObj.JsonSerialize().IL2CppJsonDeserialize<IL2CppJson.JObject>();
-                        originalSucceedCallback?.Invoke(newJObject);
-                    });
-                    OriginalSendToUrl(hiddenStructReturn, thisPtr, url, method, datas, _succeedCallback.Pointer, failCallback, startCallback, completeCallback, headers, nativeMethodInfo);
-                    break;
                 case "statistics/pc-play-statistics-feedback":
                     if(_datas["music_uid"].ToString().StartsWith($"{AlbumManager.Uid}")) {
                         Log.Debug("[SendToUrlPatch] Blocked play feedback upload:" + _datas["music_uid"].ToString());


### PR DESCRIPTION
Adds a new tag for custom charts on the top row of the tag select screen, to the left of the Hidden tag.
This replaces the previous method of replacing the Cute tag.
- Categorically appropriate
- More stable (isn't reliant on a web request)
- Doesn't sacrifice existing in-game features
- Fits nicely on the UI (for now)