### PR TITLE
Asynchronous audio loading (and .aiff/.wav)

### DIFF
--- a/src/Utils.cs
+++ b/src/Utils.cs
@@ -11,11 +11,18 @@ using System.Security.Cryptography;
 using System.Text;
 using UnhollowerBaseLib;
 using Assets.Scripts.PeroTools.Nice.Interface;
+using NLayer;
+using Assets.Scripts.PeroTools.Commons;
+using Assets.Scripts.PeroTools.Managers;
+using NVorbis.NAudioSupport;
 
 namespace CustomAlbums
 {
     public static class Utils
     {
+        public const int ASYNC_READ_SPEED = 4096;
+        private static readonly Logger Log = new Logger("Utils");
+
         unsafe public static IntPtr NativeMethod(Type type, string name, Type[] parameters = null, Type[] generics = null)
         {
             var method = AccessTools.Method(type, name, parameters, generics);
@@ -222,16 +229,106 @@ namespace CustomAlbums
             return classes;
         }
 
+        /// <summary>
+        /// Gets the result of an IVariable.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="data"></param>
+        /// <returns></returns>
         public static T GetResult<T>(this IVariable data) {
             try {
                 return VariableUtils.GetResult<T>(data);
             } catch(Exception e) {
-                MelonLoader.MelonLogger.LogError(typeof(T).ToString() + " " + e.ToString());
+                Log.Error(typeof(T).ToString() + " " + e.ToString());
                 return default(T);
             }
         }
+
+        /// <summary>
+        /// Sets the result of an IVariable.
+        /// </summary>
+        /// <param name="data"></param>
+        /// <param name="value"></param>
         public static void SetResult(this IVariable data, Il2CppSystem.Object value) {
             VariableUtils.SetResult(data, value);
+        }
+
+        /// <summary>
+        /// Begins asynchronously loading an MP3 file from the given stream.
+        /// </summary>
+        /// <param name="stream"></param>
+        /// <param name="name"></param>
+        /// <returns></returns>
+        public static UnityEngine.AudioClip BeginAsyncMp3(Stream stream, string name) {
+            var mpgFile = new MpegFile(stream);
+            var sampleCount = mpgFile.Length / sizeof(float);
+            var remaining = sampleCount;
+            var index = 0;
+            var audioClip = UnityEngine.AudioClip.Create(name, (int)sampleCount / mpgFile.Channels, mpgFile.Channels, mpgFile.SampleRate, false);
+
+            SingletonMonoBehaviour<CoroutineManager>.instance.StartCoroutine(
+                (Il2CppSystem.Action)delegate { },
+                (Il2CppSystem.Func<bool>)delegate {
+                    // Stop if the asset is unloaded during read
+                    if(audioClip == null) return true;
+
+                    var sampArr = new float[Math.Min(ASYNC_READ_SPEED, remaining)];
+                    var readCount = mpgFile.ReadSamples(sampArr, 0, sampArr.Length);
+
+                    audioClip.SetData(sampArr, index / 2);
+
+                    index += readCount;
+                    remaining -= readCount;
+
+                    if(remaining <= 0) {
+                        stream.Dispose();
+                        Log.Debug($"Finished async read of {name}.mp3");
+                        return true;
+                    }
+
+                    return false;
+                });
+
+            return audioClip;
+        }
+
+        /// <summary>
+        /// Begins asynchronously loading an OGG file from the given stream.
+        /// </summary>
+        /// <param name="stream"></param>
+        /// <param name="name"></param>
+        /// <returns></returns>
+        public static UnityEngine.AudioClip BeginAsyncOgg(Il2CppSystem.IO.Stream stream, string name) {
+            var waveStream = new VorbisWaveReader(stream);
+            var sampleCount = (int)(waveStream.Length / (waveStream.WaveFormat.BitsPerSample / 8));
+            var remaining = sampleCount;
+            var index = 0;
+            var audioClip = UnityEngine.AudioClip.Create(name, sampleCount / waveStream.WaveFormat.Channels, waveStream.WaveFormat.Channels, waveStream.WaveFormat.SampleRate, false);
+
+            SingletonMonoBehaviour<CoroutineManager>.instance.StartCoroutine(
+                (Il2CppSystem.Action)delegate { },
+                (Il2CppSystem.Func<bool>)delegate {
+                    // Stop if the asset is unloaded during read
+                    if(audioClip == null) return true;
+
+                    var dataSet = new Il2CppStructArray<float>(Math.Min(ASYNC_READ_SPEED, remaining));
+                    var readCount = waveStream.Read(dataSet, 0, dataSet.Length);
+
+                    audioClip.SetData(dataSet, index / 2);
+
+                    index += readCount;
+                    remaining -= readCount;
+
+                    if(remaining <= 0) {
+                        waveStream.Dispose();
+                        Log.Debug($"Finished async read of {name}.ogg");
+                        return true;
+                    }
+
+                    return false;
+                });
+
+            return audioClip;
         }
     }
 }


### PR DESCRIPTION
Adds asynchronous audio loading for .ogg and .mp3 formats.
Also restores functional loading of .aiff and .wav formats.

Notes:
- .aiff and .wav do not support async and still cause the temporary freeze when selected
- game no longer causes a freeze every time a new custom is selected
  - game now instead lags more as more audio files are queued up