### PR TITLE
Add DJMax scene switch note defintion

### DIFF
--- a/src/Patch/NotesPatch.cs
+++ b/src/Patch/NotesPatch.cs
@@ -1,0 +1,32 @@
+﻿using HarmonyLib;
+using Assets.Scripts.GameCore.Managers;
+using GameLogic;
+
+namespace CustomAlbums.Patch
+{
+    /// <summary>
+    /// Adds notes to the NoteDatas.
+    /// </summary>
+    [HarmonyPatch(typeof(NoteDataMananger), "Init")]
+    internal static class NotesPatch
+    {
+        private static void Postfix(NoteDataMananger __instance) {
+            // Add DJMax scene switch
+            __instance.NoteDatas.Add(new NoteConfigData {
+                ibms_id = "1W",
+
+                m_BmsUid = PeroPeroGames.GlobalDefines.BmsNodeUid.ToggleScene10,
+                id = (__instance.NoteDatas.Count + 1).ToString(),
+                des = "DJMax Scene Switch",
+                prefab_name = "000401",
+                uid = "000409",
+                noteUid = 409,
+                isShowPlayEffect = true,
+                scene = "0",
+                boss_action = "0",
+                key_audio = "0",
+                effect = "0"
+            });
+        }
+    }
+}


### PR DESCRIPTION
The vanilla game is missing a definition for the DJMax scene switch note `1W`.
This adds a patch which appends a new note definition, enabling the scene switch.