### PR TITLE
Fix DJMax victory screen

### DIFF
--- a/src/Patch/DjVictoryPatch.cs
+++ b/src/Patch/DjVictoryPatch.cs
@@ -11,7 +11,7 @@ namespace CustomAlbums.Patch
     internal static class DjVictoryPatch
     {
         private static void Postfix(PnlVictory __instance) {
-            if(GlobalDataBase.dbOther.isDjMaxScene) {
+            if(__instance.m_CurControls.mainPnl.transform.parent.name == "Djmax") {
                 var titleObj = __instance.m_CurControls.mainPnl.transform.Find("PnlVictory_3D").Find("SongTittle").Find("ImgSongTittleMask");
                 var titleNormalTxt = titleObj.Find("TxtSongTittle").gameObject;
 

--- a/src/Patch/DjVictoryPatch.cs
+++ b/src/Patch/DjVictoryPatch.cs
@@ -1,0 +1,26 @@
+﻿using HarmonyLib;
+using Assets.Scripts.Database;
+
+namespace CustomAlbums.Patch
+{
+    /// <summary>
+    /// Patches the DJMax victory screen to enable the scrolling song title object.
+    /// Fixes a vanilla bug where this object does not enable automatically.
+    /// </summary>
+    [HarmonyPatch(typeof(PnlVictory), "OnVictory")]
+    internal static class DjVictoryPatch
+    {
+        private static void Postfix(PnlVictory __instance) {
+            if(GlobalDataBase.dbOther.isDjMaxScene) {
+                var titleObj = __instance.m_CurControls.mainPnl.transform.Find("PnlVictory_3D").Find("SongTittle").Find("ImgSongTittleMask");
+                var titleNormalTxt = titleObj.Find("TxtSongTittle").gameObject;
+
+                // If the normal title text isn't active, then the scrollable text should be
+                if(!titleNormalTxt.active) {
+                    var titleScrollTxt = titleObj.Find("MaskPos").gameObject;
+                    titleScrollTxt.SetActive(true);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes a vanilla bug where the DJMax victory screen fails to enable the scrollable song title object.