### PR TITLE
Hidden chart support

### DIFF
--- a/src/Data/AlbumInfo.cs
+++ b/src/Data/AlbumInfo.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 
@@ -6,6 +7,13 @@ namespace CustomAlbums.Data
 {
     public class AlbumInfo
     {
+        public enum HideBmsMode
+        {
+            CLICK,
+            PRESS,
+            TOGGLE
+        }
+
         public string name;
         public string name_en;
         public string name_ko;
@@ -38,6 +46,11 @@ namespace CustomAlbums.Data
 
         [DefaultValue("0")]
         public string unlockLevel;
+
+        [DefaultValue("CLICK")]
+        public string hideBmsMode;
+        public int hideBmsDifficulty;
+        public string hideBmsMessage;
 
         public string GetName(string lang = null)
         {
@@ -168,6 +181,10 @@ namespace CustomAlbums.Data
                 map.Add(4, levelDesigner4);
 
             return map;
+        }
+
+        public HideBmsMode GetHideBmsMode() {
+            return Enum.TryParse(hideBmsMode, out HideBmsMode result) ? result : HideBmsMode.CLICK;
         }
     }
 }

--- a/src/Patch/HideBmsPatch.cs
+++ b/src/Patch/HideBmsPatch.cs
@@ -1,0 +1,213 @@
+﻿using HarmonyLib;
+using Newtonsoft.Json.Linq;
+using IL2CppJson = Il2CppNewtonsoft.Json.Linq;
+using Il2CppSystem.Collections.Generic;
+using Assets.Scripts.Database;
+using Assets.Scripts.Database.DataClass;
+using static Assets.Scripts.Database.DBConfigCustomTags;
+using CustomAlbums.Data;
+using System;
+using Assets.Scripts.PeroTools.Commons;
+using Assets.Scripts.UI.Controls;
+using UnhollowerBaseLib;
+using Assets.Scripts.PeroTools.Managers;
+using Assets.Scripts.UI.Tips;
+using Assets.Scripts.UI.Panels;
+using PeroPeroGames.GlobalDefines;
+
+namespace CustomAlbums.Patch
+{
+    /// <summary>
+    /// Adds custom albums with hidden charts to the list
+    /// </summary>
+    [HarmonyPatch(typeof(SpecialSongManager), "InitHideBmsInfoDic")]
+    internal static class HideBmsInfoDicPatch {
+        private static bool runOnce;
+
+        private static void Postfix(SpecialSongManager __instance) {
+            if(!runOnce) {
+                var albumList = new List<string>();
+
+                foreach(var album in AlbumManager.LoadedAlbums) {
+                    if(album.Value.availableMaps.ContainsKey(4)) {
+                        __instance.m_HideBmsInfos.Add($"{AlbumManager.Uid}-{album.Value.Index}",
+                        new SpecialSongManager.HideBmsInfo(
+                            $"{AlbumManager.Uid}-{album.Value.Index}",
+                            album.Value.Info.hideBmsDifficulty == 0 ? (album.Value.availableMaps.ContainsKey(3) ? 3 : 2) : album.Value.Info.hideBmsDifficulty,
+                            4,
+                            $"{album.Value.Name}_map4",
+                            (Il2CppSystem.Func<bool>)delegate { return __instance.IsInvokeHideBms($"{AlbumManager.Uid}-{album.Value.Index}"); }
+                        ));
+
+                        // Add chart to the appropriate list for their hidden type
+                        switch(album.Value.Info.GetHideBmsMode()) {
+                            case AlbumInfo.HideBmsMode.CLICK:
+                                var newClickArr = new Il2CppStringArray(__instance.m_ClickHideUids.Length + 1);
+                                for(int i = 0; i < __instance.m_ClickHideUids.Length; i++) newClickArr[i] = __instance.m_ClickHideUids[i];
+                                newClickArr[newClickArr.Length - 1] = ($"{AlbumManager.Uid}-{album.Value.Index}");
+                                __instance.m_ClickHideUids = newClickArr;
+                                break;
+                            case AlbumInfo.HideBmsMode.PRESS:
+                                var newPressArr = new Il2CppStringArray(__instance.m_LongPressHideUids.Length + 1);
+                                for(int i = 0; i < __instance.m_LongPressHideUids.Length; i++) newPressArr[i] = __instance.m_LongPressHideUids[i];
+                                newPressArr[newPressArr.Length - 1] = ($"{AlbumManager.Uid}-{album.Value.Index}");
+                                __instance.m_LongPressHideUids = newPressArr;
+                                break;
+                            case AlbumInfo.HideBmsMode.TOGGLE:
+                                var newToggleArr = new Il2CppStringArray(__instance.m_ToggleChangedHideUids.Length + 1);
+                                for(int i = 0; i < __instance.m_ToggleChangedHideUids.Length; i++) newToggleArr[i] = __instance.m_ToggleChangedHideUids[i];
+                                newToggleArr[newToggleArr.Length - 1] = ($"{AlbumManager.Uid}-{album.Value.Index}");
+                                __instance.m_ToggleChangedHideUids = newToggleArr;
+                                break;
+                            default:
+                                break;
+                        }
+
+                        // Add chart to the "With Hidden Chart" tag
+                        /*albumList.Add($"{AlbumManager.Uid}-{album.Value.Index}");
+
+                        var newArr = new Il2CppStringArray(DBMusicTagDefine.s_HiddenLocal.Length + 1);
+                        for(int i = 0; i < DBMusicTagDefine.s_HiddenLocal.Count; i++) {
+                            newArr[i] = DBMusicTagDefine.s_HiddenLocal[i];
+                        }
+                        newArr[newArr.Length - 1] = $"{AlbumManager.Uid}-{album.Value.Index}";
+                        DBMusicTagDefine.s_HiddenLocal = newArr;*/
+                    }
+                }
+
+                //var tagInfo = GlobalDataBase.dbMusicTag.GetAlbumTagInfo(32776);
+                //tagInfo.AddTagUids(albumList);
+
+                // This may run multiple times, but creates data which can only be generated once
+                runOnce = true;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Activates hidden charts when the conditions are met
+    /// </summary>
+    [HarmonyPatch(typeof(SpecialSongManager), "InvokeHideBms")]
+    internal static class InvokeHideBmsPatch {
+        private static bool Prefix(DBConfigALBUM.MusicInfo musicInfo, SpecialSongManager __instance) {
+            if(musicInfo.uid.StartsWith(AlbumManager.Uid.ToString()) && __instance.m_HideBmsInfos.ContainsKey(musicInfo.uid)) {
+                var hideBms = __instance.m_HideBmsInfos[musicInfo.uid];
+                __instance.m_IsInvokeHideDic[hideBms.uid] = true;
+
+                if(hideBms.extraCondition.Invoke()) {
+                    var album = AlbumManager.LoadedAlbums[AlbumManager.GetAlbumKeyByIndex(musicInfo.musicIndex)];
+
+                    ActivateHidden(hideBms);
+
+                    var msgBox = PnlTipsManager.instance.GetMessageBox("PnlSpecialsBmsAsk");
+                    msgBox.Show("TIPS", album.Info.hideBmsMessage);
+                    SpecialSongManager.onTriggerHideBmsEvent?.Invoke();
+                    if(album.Info.GetHideBmsMode() == AlbumInfo.HideBmsMode.PRESS) Singleton<EventManager>.instance.Invoke("UI/OnSpecialsMusic", null);
+                }
+                return false;
+            }
+            return true;
+        }
+
+        private static bool ActivateHidden(SpecialSongManager.HideBmsInfo hideBms) {
+            if(hideBms == null) return false;
+
+            var info = GlobalDataBase.dbMusicTag.GetMusicInfoFromAll(hideBms.uid);
+            var success = false;
+            if(hideBms.triggerDiff != 0) {
+                var targetDiff = hideBms.triggerDiff;
+                if(targetDiff == -1) {
+                    targetDiff = 2;
+
+                    // Disable the other difficulty options
+                    info.AddMaskValue("difficulty1", "0");
+                    info.AddMaskValue("difficulty3", "0");
+                }
+                var diffToHide = "difficulty" + targetDiff;
+                var levelDesignToHide = "levelDesigner" + targetDiff;
+                var diffStr = "?";
+                var levelDesignStr = info.levelDesigner;
+                switch(hideBms.m_HideDiff) {
+                    case 1:
+                        diffStr = info.difficulty1;
+                        levelDesignStr = info.levelDesigner1 ?? info.levelDesigner;
+                        break;
+                    case 2:
+                        diffStr = info.difficulty2;
+                        levelDesignStr = info.levelDesigner2 ?? info.levelDesigner;
+                        break;
+                    case 3:
+                        diffStr = info.difficulty3;
+                        levelDesignStr = info.levelDesigner3 ?? info.levelDesigner;
+                        break;
+                    case 4:
+                        diffStr = info.difficulty4;
+                        levelDesignStr = info.levelDesigner4 ?? info.levelDesigner;
+                        break;
+                    case 5:
+                        diffStr = info.difficulty5;
+                        levelDesignStr = info.levelDesigner5 ?? info.levelDesigner;
+                        break;
+                }
+                info.AddMaskValue(diffToHide, diffStr);
+                info.AddMaskValue(levelDesignToHide, levelDesignStr);
+                info.SetDifficulty(targetDiff, hideBms.m_HideDiff);
+
+                MelonLoader.MelonLogger.Log($"Activated hidden chart {hideBms.uid}");
+                success = true;
+            }
+
+            return success;
+        }
+    }
+
+    /// <summary>
+    /// Turns off custom hiddens when leaving a chart
+    /// </summary>
+    [HarmonyPatch(typeof(PnlStage), "PreWarm")]
+    internal static class FixInvokeHideBms
+    {
+        private static void Postfix() {
+            var invokeHideKeys = Singleton<SpecialSongManager>.instance.m_IsInvokeHideDic.Keys;
+            var newKeys = new List<string>();
+            foreach(var key in invokeHideKeys) {
+                if(key.StartsWith(AlbumManager.Uid.ToString())) {
+                    newKeys.Add(key);
+                }
+            }
+            foreach(var key in newKeys) {
+                Singleton<SpecialSongManager>.instance.m_IsInvokeHideDic[key] = false;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Adds charts to the "With Hidden Sheet" tag
+    /// </summary>
+    [HarmonyPatch(typeof(MusicTagManager), "InitDefaultInfo")]
+    internal static class AddHiddenSheetTagPatch
+    {
+        private static bool runOnce;
+
+        private static void Postfix() {
+            if(!runOnce) {
+                var albumList = new List<string>();
+                foreach(var album in AlbumManager.LoadedAlbums) {
+                    if(album.Value.availableMaps.ContainsKey(4)) {
+                        albumList.Add($"{AlbumManager.Uid}-{album.Value.Index}");
+
+                        var newArr = new Il2CppStringArray(DBMusicTagDefine.s_HiddenLocal.Length + 1);
+                        for(int i = 0; i < DBMusicTagDefine.s_HiddenLocal.Count; i++) {
+                            newArr[i] = DBMusicTagDefine.s_HiddenLocal[i];
+                        }
+                        newArr[newArr.Length - 1] = $"{AlbumManager.Uid}-{album.Value.Index}";
+                        DBMusicTagDefine.s_HiddenLocal = newArr;
+                    }
+                }
+                var tagInfo = GlobalDataBase.dbMusicTag.GetAlbumTagInfo(32776);
+                tagInfo.AddTagUids(albumList);
+                runOnce = true;
+            }
+        }
+    }
+}

--- a/src/Patch/HideBmsPatch.cs
+++ b/src/Patch/HideBmsPatch.cs
@@ -1,18 +1,11 @@
 ﻿using HarmonyLib;
-using Newtonsoft.Json.Linq;
-using IL2CppJson = Il2CppNewtonsoft.Json.Linq;
 using Il2CppSystem.Collections.Generic;
 using Assets.Scripts.Database;
-using Assets.Scripts.Database.DataClass;
-using static Assets.Scripts.Database.DBConfigCustomTags;
 using CustomAlbums.Data;
-using System;
 using Assets.Scripts.PeroTools.Commons;
-using Assets.Scripts.UI.Controls;
 using UnhollowerBaseLib;
 using Assets.Scripts.PeroTools.Managers;
 using Assets.Scripts.UI.Tips;
-using Assets.Scripts.UI.Panels;
 using PeroPeroGames.GlobalDefines;
 
 namespace CustomAlbums.Patch
@@ -27,14 +20,16 @@ namespace CustomAlbums.Patch
         private static void Postfix(SpecialSongManager __instance) {
             if(!runOnce) {
                 foreach(var album in AlbumManager.LoadedAlbums) {
+                    var albumUid = $"{AlbumManager.Uid}-{album.Value.Index}";
+                    // Enable hidden mode for charts containing map4
                     if(album.Value.availableMaps.ContainsKey(4)) {
                         __instance.m_HideBmsInfos.Add($"{AlbumManager.Uid}-{album.Value.Index}",
                         new SpecialSongManager.HideBmsInfo(
-                            $"{AlbumManager.Uid}-{album.Value.Index}",
+                            albumUid,
                             album.Value.Info.hideBmsDifficulty == 0 ? (album.Value.availableMaps.ContainsKey(3) ? 3 : 2) : album.Value.Info.hideBmsDifficulty,
                             4,
                             $"{album.Value.Name}_map4",
-                            (Il2CppSystem.Func<bool>)delegate { return __instance.IsInvokeHideBms($"{AlbumManager.Uid}-{album.Value.Index}"); }
+                            (Il2CppSystem.Func<bool>)delegate { return __instance.IsInvokeHideBms(albumUid); }
                         ));
 
                         // Add chart to the appropriate list for their hidden type
@@ -42,19 +37,19 @@ namespace CustomAlbums.Patch
                             case AlbumInfo.HideBmsMode.CLICK:
                                 var newClickArr = new Il2CppStringArray(__instance.m_ClickHideUids.Length + 1);
                                 for(int i = 0; i < __instance.m_ClickHideUids.Length; i++) newClickArr[i] = __instance.m_ClickHideUids[i];
-                                newClickArr[newClickArr.Length - 1] = ($"{AlbumManager.Uid}-{album.Value.Index}");
+                                newClickArr[newClickArr.Length - 1] = albumUid;
                                 __instance.m_ClickHideUids = newClickArr;
                                 break;
                             case AlbumInfo.HideBmsMode.PRESS:
                                 var newPressArr = new Il2CppStringArray(__instance.m_LongPressHideUids.Length + 1);
                                 for(int i = 0; i < __instance.m_LongPressHideUids.Length; i++) newPressArr[i] = __instance.m_LongPressHideUids[i];
-                                newPressArr[newPressArr.Length - 1] = ($"{AlbumManager.Uid}-{album.Value.Index}");
+                                newPressArr[newPressArr.Length - 1] = albumUid;
                                 __instance.m_LongPressHideUids = newPressArr;
                                 break;
                             case AlbumInfo.HideBmsMode.TOGGLE:
                                 var newToggleArr = new Il2CppStringArray(__instance.m_ToggleChangedHideUids.Length + 1);
                                 for(int i = 0; i < __instance.m_ToggleChangedHideUids.Length; i++) newToggleArr[i] = __instance.m_ToggleChangedHideUids[i];
-                                newToggleArr[newToggleArr.Length - 1] = ($"{AlbumManager.Uid}-{album.Value.Index}");
+                                newToggleArr[newToggleArr.Length - 1] = albumUid;
                                 __instance.m_ToggleChangedHideUids = newToggleArr;
                                 break;
                             default:

--- a/src/Patch/HideBmsPatch.cs
+++ b/src/Patch/HideBmsPatch.cs
@@ -26,8 +26,6 @@ namespace CustomAlbums.Patch
 
         private static void Postfix(SpecialSongManager __instance) {
             if(!runOnce) {
-                var albumList = new List<string>();
-
                 foreach(var album in AlbumManager.LoadedAlbums) {
                     if(album.Value.availableMaps.ContainsKey(4)) {
                         __instance.m_HideBmsInfos.Add($"{AlbumManager.Uid}-{album.Value.Index}",
@@ -62,21 +60,8 @@ namespace CustomAlbums.Patch
                             default:
                                 break;
                         }
-
-                        // Add chart to the "With Hidden Chart" tag
-                        /*albumList.Add($"{AlbumManager.Uid}-{album.Value.Index}");
-
-                        var newArr = new Il2CppStringArray(DBMusicTagDefine.s_HiddenLocal.Length + 1);
-                        for(int i = 0; i < DBMusicTagDefine.s_HiddenLocal.Count; i++) {
-                            newArr[i] = DBMusicTagDefine.s_HiddenLocal[i];
-                        }
-                        newArr[newArr.Length - 1] = $"{AlbumManager.Uid}-{album.Value.Index}";
-                        DBMusicTagDefine.s_HiddenLocal = newArr;*/
                     }
                 }
-
-                //var tagInfo = GlobalDataBase.dbMusicTag.GetAlbumTagInfo(32776);
-                //tagInfo.AddTagUids(albumList);
 
                 // This may run multiple times, but creates data which can only be generated once
                 runOnce = true;
@@ -99,8 +84,10 @@ namespace CustomAlbums.Patch
 
                     ActivateHidden(hideBms);
 
-                    var msgBox = PnlTipsManager.instance.GetMessageBox("PnlSpecialsBmsAsk");
-                    msgBox.Show("TIPS", album.Info.hideBmsMessage);
+                    if(album.Info.hideBmsMessage != null) {
+                        var msgBox = PnlTipsManager.instance.GetMessageBox("PnlSpecialsBmsAsk");
+                        msgBox.Show("TIPS", album.Info.hideBmsMessage);
+                    }
                     SpecialSongManager.onTriggerHideBmsEvent?.Invoke();
                     if(album.Info.GetHideBmsMode() == AlbumInfo.HideBmsMode.PRESS) Singleton<EventManager>.instance.Invoke("UI/OnSpecialsMusic", null);
                 }
@@ -153,31 +140,10 @@ namespace CustomAlbums.Patch
                 info.AddMaskValue(levelDesignToHide, levelDesignStr);
                 info.SetDifficulty(targetDiff, hideBms.m_HideDiff);
 
-                MelonLoader.MelonLogger.Log($"Activated hidden chart {hideBms.uid}");
                 success = true;
             }
 
             return success;
-        }
-    }
-
-    /// <summary>
-    /// Turns off custom hiddens when leaving a chart
-    /// </summary>
-    [HarmonyPatch(typeof(PnlStage), "PreWarm")]
-    internal static class FixInvokeHideBms
-    {
-        private static void Postfix() {
-            var invokeHideKeys = Singleton<SpecialSongManager>.instance.m_IsInvokeHideDic.Keys;
-            var newKeys = new List<string>();
-            foreach(var key in invokeHideKeys) {
-                if(key.StartsWith(AlbumManager.Uid.ToString())) {
-                    newKeys.Add(key);
-                }
-            }
-            foreach(var key in newKeys) {
-                Singleton<SpecialSongManager>.instance.m_IsInvokeHideDic[key] = false;
-            }
         }
     }
 


### PR DESCRIPTION
Adds support for charts with "hidden" difficulties.
Hidden difficulties use the (previously unused) settings for map 4.
A hidden mode for a chart is only generated when map 4 exists, regardless of options.

Three different access options are currently available:
- `CLICK`: Default. Click the target difficulty option enough times and it switches to the hidden difficulty.
- `PRESS`: Hold click on the chart's record in song select and it switches to the hidden difficulty.
- `TOGGLE`: Toggle through the difficulty options in ascending/descending order and it switches to the hidden difficulty.
  - Requires the chart to have easy, hard, and master difficulties available.

This also adds three new parameters to `info.json`:
- `hideBmsMode`: Defaults to `CLICK`. Can be one of `CLICK|PRESS|TOGGLE`. Determines the access method.
- `hideBmsDifficulty`: Defaults to `0`, which automatically selects Hard or Master, if available.
  - Difficulty must be with the range of `-1` to `3`.
  - Determines which difficulty option the hidden chart will replace.
  - Determines which difficulty must be clicked on for `CLICK` mode.
  - For `PRESS` mode, the difficulty can be chosen to replace an empty position. 
    - For example, difficulty 3 on a chart with no Master difficulty.
  - Using -1 causes the chart to replace all difficulty options with one Hard difficulty set to the hidden chart.
    - This should ONLY be used alongside `PRESS` mode to avoid bugs.
- `hideBmsMessage`: Providing a message causes a message box to appear with the message on activation.