### PR TITLE
Async audio improvements

### DIFF
--- a/src/Album.cs
+++ b/src/Album.cs
@@ -161,7 +161,7 @@ namespace CustomAlbums
                     return null;
                 }
 
-                var audioName = $"{Info.name}_{name}";
+                var audioName = $"{Name}_{name}";
                 AudioClip audioClip = null;
 
                 switch (format)
@@ -171,10 +171,10 @@ namespace CustomAlbums
                         audioClip = Manager.Load(buffer.ToIL2CppStream(), format, audioName);
                         break;
                     case AudioFormat.ogg:
-                        audioClip = Utils.BeginAsyncOgg(buffer.ToIL2CppStream(), audioName);
+                        audioClip = AsyncBgmManager.BeginAsyncOgg(buffer.ToIL2CppStream(), audioName);
                         break;
                     case AudioFormat.mp3:
-                        audioClip = Utils.BeginAsyncMp3(buffer.ToStream(), audioName);
+                        audioClip = AsyncBgmManager.BeginAsyncMp3(buffer.ToStream(), audioName);
                         break;
                 }
 

--- a/src/AsyncBgmManager.cs
+++ b/src/AsyncBgmManager.cs
@@ -1,0 +1,140 @@
+using HarmonyLib;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using UnhollowerBaseLib;
+using NLayer;
+using Assets.Scripts.PeroTools.Commons;
+using Assets.Scripts.PeroTools.Managers;
+using NVorbis.NAudioSupport;
+using UnityEngine;
+
+namespace CustomAlbums
+{
+    public static class AsyncBgmManager
+    {
+        public const int ASYNC_READ_SPEED = 4096;
+        private static readonly Logger Log = new Logger("AsyncBgmManager");
+
+        private static Coroutine currentRoutine;
+        private static Dictionary<string, Coroutine> coroutines = new Dictionary<string, Coroutine>();
+
+        /// <summary>
+        /// Attempts to switch the current audio load coroutine to the given audio name.
+        /// Returns whether the switch was successful.
+        /// </summary>
+        /// <param name="audioName"></param>
+        /// <returns></returns>
+        public static bool TrySwitchLoad(string audioName) {
+            if(coroutines.TryGetValue(audioName, out Coroutine routine)) {
+                currentRoutine = routine;
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Begins asynchronously loading an MP3 file from the given stream and sets itself as the current audio coroutine.
+        /// </summary>
+        /// <param name="stream"></param>
+        /// <param name="name"></param>
+        /// <returns></returns>
+        public static AudioClip BeginAsyncMp3(Stream stream, string name) {
+            var mpgFile = new MpegFile(stream);
+            var sampleCount = mpgFile.Length / sizeof(float);
+            var remaining = sampleCount;
+            var index = 0;
+            var audioClip = AudioClip.Create(name, (int)sampleCount / mpgFile.Channels, mpgFile.Channels, mpgFile.SampleRate, false);
+            
+            Coroutine routine = null;
+            routine = SingletonMonoBehaviour<CoroutineManager>.instance.StartCoroutine(
+                (Il2CppSystem.Action)delegate { },
+                (Il2CppSystem.Func<bool>)delegate {
+                    // Stop if the asset is unloaded during read
+                    if(audioClip == null) {
+                        coroutines.Remove(name);
+                        if(currentRoutine == routine) currentRoutine = null;
+                        Log.Debug($"Aborting async load of {name}.mp3");
+                        return true;
+                    }
+
+                    // Pause when not the current routine
+                    if(currentRoutine != routine) return false;
+
+                    var sampArr = new float[Math.Min(ASYNC_READ_SPEED, remaining)];
+                    var readCount = mpgFile.ReadSamples(sampArr, 0, sampArr.Length);
+
+                    audioClip.SetData(sampArr, index / mpgFile.Channels);
+
+                    index += readCount;
+                    remaining -= readCount;
+                    if(remaining <= 0 || readCount == 0) {
+                        stream.Dispose();
+                        Log.Debug($"Finished async read of {name}.mp3");
+                        currentRoutine = null;
+                        coroutines.Remove(name);
+                        return true;
+                    }
+
+                    return false;
+                });
+            currentRoutine = routine;
+            coroutines[name] = routine;
+
+            return audioClip;
+        }
+
+        /// <summary>
+        /// Begins asynchronously loading an OGG file from the given stream and sets itself as the current audio coroutine.
+        /// </summary>
+        /// <param name="stream"></param>
+        /// <param name="name"></param>
+        /// <returns></returns>
+        public static AudioClip BeginAsyncOgg(Il2CppSystem.IO.Stream stream, string name) {
+            var waveStream = new VorbisWaveReader(stream);
+            var sampleCount = (int)(waveStream.Length / (waveStream.WaveFormat.BitsPerSample / 8));
+            var remaining = sampleCount;
+            var index = 0;
+            var audioClip = AudioClip.Create(name, sampleCount / waveStream.WaveFormat.Channels, waveStream.WaveFormat.Channels, waveStream.WaveFormat.SampleRate, false);
+
+            Coroutine routine = null;
+            routine = SingletonMonoBehaviour<CoroutineManager>.instance.StartCoroutine(
+                (Il2CppSystem.Action)delegate { },
+                (Il2CppSystem.Func<bool>)delegate {
+                    // Stop if the asset is unloaded during read
+                    if(audioClip == null) {
+                        coroutines.Remove(name);
+                        if(currentRoutine == routine) currentRoutine = null;
+                        Log.Debug($"Aborting async load of {name}.ogg");
+                        return true;
+                    }
+
+                    // Pause when not the current routine
+                    if(currentRoutine != routine) return false;
+
+                    var dataSet = new Il2CppStructArray<float>(Math.Min(ASYNC_READ_SPEED, remaining));
+                    var readCount = waveStream.Read(dataSet, 0, dataSet.Length);
+
+                    audioClip.SetData(dataSet, index / waveStream.WaveFormat.Channels);
+
+                    index += readCount;
+                    remaining -= readCount;
+                    if(remaining <= 0 || readCount == 0) {
+                        waveStream.Dispose();
+                        Log.Debug($"Finished async read of {name}.ogg");
+                        currentRoutine = null;
+                        coroutines.Remove(name);
+                        return true;
+                    }
+
+                    return false;
+                });
+            currentRoutine = routine;
+            coroutines[name] = routine;
+
+            return audioClip;
+        }
+    }
+}

--- a/src/Patch/AssetPatch.cs
+++ b/src/Patch/AssetPatch.cs
@@ -58,7 +58,11 @@ namespace CustomAlbums.Patch
             if (LoadedAssets.TryGetValue(_assetName, out var asset))
             {
                 if(asset != null) {
-                    Log.Debug($"Use cache: {_assetName}");
+                    if(AsyncBgmManager.TrySwitchLoad(_assetName)) {
+                        Log.Debug($"Resuming async load of {_assetName}");
+                    } else {
+                        Log.Debug($"Use cache: {_assetName}");
+                    }
                     return asset.Pointer;
                 } else {
                     Log.Debug("Replacing null asset");


### PR DESCRIPTION
Splits off async audio control to its own static class.
Audio load coroutines pause themselves when their BGM is not in use, and resume when needed.

Fixes an issue where audio with other than 2 channels would not load correctly.