### PR TITLE
Make PPG not gay again

### DIFF
--- a/src/Album.cs
+++ b/src/Album.cs
@@ -165,7 +165,7 @@ namespace CustomAlbums
             {
                 if (!AudioFormatMapping.TryGetValue(Path.GetExtension(fileName), out var format))
                 {
-                    Log.Debug($"Unknown audio format: {fileName} from: {BasePath}");
+                    Log.Warning($"Unknown audio format: {fileName} from: {BasePath}");
                     return null;
                 }
 

--- a/src/Patch/PeroPeroGaysPatch.cs
+++ b/src/Patch/PeroPeroGaysPatch.cs
@@ -1,0 +1,19 @@
+﻿using HarmonyLib;
+
+namespace CustomAlbums.Patch
+{
+	/// <summary>
+	/// Stops PPG from being gay
+	/// 
+	/// Actual function: Disables the check on number of files within game directories for the purpose of Steam API initialization.
+	/// Fixes an issue where any excess files in the base game directory would cause it to refuse to recognize the DLC.
+	/// </summary>
+	[HarmonyPatch(typeof(SteamManager), nameof(SteamManager.DoSomething2))]
+	internal static class PeroPeroGaysPatch
+	{
+		private static bool Prefix(ref bool __result) {
+			__result = true;
+			return false;
+		}
+	}
+}


### PR DESCRIPTION
- Fix PPG-introduced issue where any excess files in the base game directory causes the game to fail Steam API initialization checks
- Fix one instance of incorrect logging levels in Album.cs